### PR TITLE
fix: exception handler - handleMethodArgumentNotValid

### DIFF
--- a/src/main/java/com/lotdiz/projectservice/exceptionhandler/ProjectRestControllerAdvice.java
+++ b/src/main/java/com/lotdiz/projectservice/exceptionhandler/ProjectRestControllerAdvice.java
@@ -5,88 +5,95 @@ import com.lotdiz.projectservice.utils.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
 @RestControllerAdvice
-public class ProjectRestControllerAdvice {
+public class ProjectRestControllerAdvice extends ResponseEntityExceptionHandler {
 
-    private static final String UNIQUE_CONSTRAINT_EXCEPTION_MESSAGE = "유니크 제약조건 오류";
-    private static final String DUPLICATE_KEY_EXCEPTION_MESSAGE = "중복 키 오류";
-    private static final String DOMAIN_EXCEPTION_MESSAGE = "도메인 오류";
+  private static final String UNIQUE_CONSTRAINT_EXCEPTION_MESSAGE = "유니크 제약조건 오류";
+  private static final String DUPLICATE_KEY_EXCEPTION_MESSAGE = "중복 키 오류";
+  private static final String DOMAIN_EXCEPTION_MESSAGE = "도메인 오류";
+  private static final String METHOD_ARGUMENT_NOT_VALID_EXCEPTION_MESSAGE = "VALIDATION 오류";
 
-    @ExceptionHandler(DomainException.class)
-    public ResponseEntity<ErrorResponse> domainException(DomainException e) {
-        int statusCode = e.getStatusCode();
+  @ExceptionHandler(DomainException.class)
+  public ResponseEntity<ErrorResponse> domainException(DomainException e) {
+    int statusCode = e.getStatusCode();
 
-        ErrorResponse body = ErrorResponse.builder()
-                .code(String.valueOf(statusCode))
-                .message(DOMAIN_EXCEPTION_MESSAGE)
-                .detail(e.getMessage())
-                .build();
+    ErrorResponse body =
+        ErrorResponse.builder()
+            .code(String.valueOf(statusCode))
+            .message(DOMAIN_EXCEPTION_MESSAGE)
+            .detail(e.getMessage())
+            .build();
 
-        return ResponseEntity.status(statusCode).body(body);
-    }
+    return ResponseEntity.status(statusCode).body(body);
+  }
 
-    @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<ErrorResponse> constraintViolationException(
-            DataIntegrityViolationException e) {
-        log.error("{}", e.getMessage());
-        int statusCode = HttpStatus.BAD_REQUEST.value();
-        ErrorResponse body =
-                ErrorResponse.builder()
-                        .code(String.valueOf(statusCode))
-                        .message(UNIQUE_CONSTRAINT_EXCEPTION_MESSAGE)
-                        .detail(e.getMessage())
-                        .build();
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ResponseEntity<ErrorResponse> constraintViolationException(
+      DataIntegrityViolationException e) {
+    log.error("{}", e.getMessage());
+    int statusCode = HttpStatus.BAD_REQUEST.value();
+    ErrorResponse body =
+        ErrorResponse.builder()
+            .code(String.valueOf(statusCode))
+            .message(UNIQUE_CONSTRAINT_EXCEPTION_MESSAGE)
+            .detail(e.getMessage())
+            .build();
 
-        return ResponseEntity.status(statusCode).body(body);
-    }
+    return ResponseEntity.status(statusCode).body(body);
+  }
 
-    @ExceptionHandler(DuplicateKeyException.class)
-    public ResponseEntity<ErrorResponse> duplicateKeyException(DuplicateKeyException e) {
-        log.error("{}", e.getMessage());
-        int statusCode = HttpStatus.BAD_REQUEST.value();
-        ErrorResponse body =
-                ErrorResponse.builder()
-                        .code(String.valueOf(statusCode))
-                        .message(DUPLICATE_KEY_EXCEPTION_MESSAGE)
-                        .detail(e.getMessage())
-                        .build();
+  @ExceptionHandler(DuplicateKeyException.class)
+  public ResponseEntity<ErrorResponse> duplicateKeyException(DuplicateKeyException e) {
+    log.error("{}", e.getMessage());
+    int statusCode = HttpStatus.BAD_REQUEST.value();
+    ErrorResponse body =
+        ErrorResponse.builder()
+            .code(String.valueOf(statusCode))
+            .message(DUPLICATE_KEY_EXCEPTION_MESSAGE)
+            .detail(e.getMessage())
+            .build();
 
-        return ResponseEntity.status(statusCode).body(body);
-    }
+    return ResponseEntity.status(statusCode).body(body);
+  }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> invalidRequestHandler(MethodArgumentNotValidException e) {
-        log.error("{}", e.getMessage());
-        int statusCode = HttpStatus.BAD_REQUEST.value();
-        ErrorResponse errorResponse =
-                ErrorResponse.builder()
-                        .code(String.valueOf(statusCode))
-                        .message(
-                                e.getBindingResult().getFieldError() == null
-                                        ? e.getMessage()
-                                        : e.getBindingResult().getFieldError().getDefaultMessage())
-                        .detail(e.getCause().getMessage())
-                        .build();
-        return ResponseEntity.status(statusCode).body(errorResponse);
-    }
+  @Override
+  protected ResponseEntity<Object> handleMethodArgumentNotValid(
+      MethodArgumentNotValidException e,
+      HttpHeaders headers,
+      HttpStatus status,
+      WebRequest request) {
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> exception(Exception e) {
-        log.error("{}", e.getMessage());
-        int statusCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
-        ErrorResponse errorResponse =
-                ErrorResponse.builder().code(String.valueOf(statusCode)).message(e.getMessage()).build();
-        return ResponseEntity.status(statusCode).body(errorResponse);
-    }
+    log.error("{}", e.getMessage());
 
+    ErrorResponse body =
+        ErrorResponse.builder()
+            .code(String.valueOf(HttpStatus.BAD_REQUEST.value()))
+            .message(METHOD_ARGUMENT_NOT_VALID_EXCEPTION_MESSAGE)
+            .detail(
+                e.getBindingResult().getFieldError() == null
+                    ? e.getMessage()
+                    : e.getBindingResult().getFieldError().getDefaultMessage())
+            .build();
 
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST.value()).body(body);
+  }
 
-
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> exception(Exception e) {
+    log.error("{}", e.getMessage());
+    int statusCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
+    ErrorResponse errorResponse =
+        ErrorResponse.builder().code(String.valueOf(statusCode)).message(e.getMessage()).build();
+    return ResponseEntity.status(statusCode).body(errorResponse);
+  }
 }


### PR DESCRIPTION
## pull request 설명
- ProjectRestControllerAdvice extends ResponseEntityExceptionHandler
- update handleMethodArgumentNotValid errorResponse

### 변경 사항

- [x] fix bug
- [ ] add comment
- [ ] add new feature
- [ ] update documents
- [ ] Improvement(refactoring and improving code)
- [ ] etc
